### PR TITLE
feat(UNT-T9534): props customisation in MultiStory

### DIFF
--- a/src/components/MultiStory/MultiStory.tsx
+++ b/src/components/MultiStory/MultiStory.tsx
@@ -1,42 +1,50 @@
-import React, { useState } from 'react';
+import React, { forwardRef, useImperativeHandle, useState } from 'react';
 import { View, FlatList } from 'react-native';
 import { MultiStoryContainer } from '../MultiStoryContainer';
 import { StoryAvatar } from '../StoryAvatar';
 import styles from './styles';
-import type { MultiStoryProps } from './types';
+import type { MultiStoryProps, MultiStoryRef } from './types';
 
-const MultiStory = ({ stories, ...props }: MultiStoryProps) => {
-  const [isStoryViewShow, setIsStoryViewShow] = useState<boolean>(false);
-  const [pressedIndex, setPressedIndex] = useState<number>(0);
+const MultiStory = forwardRef<MultiStoryRef, MultiStoryProps>(
+  ({ stories, ...props }, ref) => {
+    const [isStoryViewShow, setIsStoryViewShow] = useState<boolean>(false);
+    const [pressedIndex, setPressedIndex] = useState<number>(0);
 
-  const openStories = (index: number) => {
-    setIsStoryViewShow(true);
-    setPressedIndex(index);
-  };
+    const openStories = (index: number) => {
+      setIsStoryViewShow(true);
+      setPressedIndex(index);
+    };
 
-  return (
-    <View style={styles.container}>
-      <FlatList
-        horizontal
-        data={stories}
-        keyExtractor={item => item.id!.toString()}
-        renderItem={({ item, index }) => {
-          return <StoryAvatar {...{ item, index, openStories }} />;
-        }}
-        {...props}
-      />
-      {isStoryViewShow && (
-        <MultiStoryContainer
-          visible={isStoryViewShow}
-          onComplete={() => {
-            setIsStoryViewShow(false);
+    useImperativeHandle(ref, () => ({
+      close: () => setIsStoryViewShow(false),
+    }));
+
+    return (
+      <View style={styles.container}>
+        <FlatList
+          horizontal
+          data={stories}
+          keyExtractor={item => item.id!.toString()}
+          renderItem={({ item, index }) => {
+            return <StoryAvatar {...{ item, index, openStories }} />;
           }}
-          storyIndex={pressedIndex}
-          stories={stories}
+          {...props}
         />
-      )}
-    </View>
-  );
-};
+        {isStoryViewShow && (
+          <MultiStoryContainer
+            visible={isStoryViewShow}
+            onComplete={() => {
+              props?.onComplete?.();
+              setIsStoryViewShow(false);
+            }}
+            {...props?.storyContainerProps}
+            stories={stories}
+            userStoryIndex={pressedIndex}
+          />
+        )}
+      </View>
+    );
+  }
+);
 
 export default MultiStory;

--- a/src/components/MultiStory/types.ts
+++ b/src/components/MultiStory/types.ts
@@ -1,4 +1,9 @@
-import type { StoriesType } from '../StoryView/types';
-export interface MultiStoryProps {
+import type { StoriesType, StoryContainerProps } from '../StoryView/types';
+export interface MultiStoryProps extends StoryContainerProps {
   stories: StoriesType[];
+  storyContainerProps?: Omit<StoryContainerProps, 'stories'>;
+}
+
+export interface MultiStoryRef {
+  close: () => void;
 }

--- a/src/components/MultiStoryContainer/MultiStoryContainer.tsx
+++ b/src/components/MultiStoryContainer/MultiStoryContainer.tsx
@@ -19,33 +19,38 @@ const MultiStoryListItem = ({
   previousStory,
   storyIndex,
   onComplete,
-}: MultiStoryListItemProps) => (
-  <Animated.View key={item.id} style={styles.itemContainer}>
-    <Animated.View style={animatedTransitionStyle(index)}>
-      <StoryContainer
-        visible={true}
-        nextStory={nextStory}
-        previousStory={previousStory}
-        index={index}
-        storyIndex={storyIndex}
-        stories={item.stories}
-        progressIndex={0}
-        maxVideoDuration={10}
-        headerComponent={
-          <UserHeaderView
-            userImage={{ uri: item.profile ?? '' }}
-            userName={item.username}
-            userMessage={item.title}
-            onClosePress={() => {
-              onComplete?.();
-            }}
-          />
-        }
-        footerComponent={<Footer />}
-      />
+  ...props
+}: MultiStoryListItemProps) => {
+  return (
+    <Animated.View key={item.id} style={styles.itemContainer}>
+      <Animated.View style={animatedTransitionStyle(index)}>
+        <StoryContainer
+          visible={true}
+          userStories={item}
+          nextStory={nextStory}
+          previousStory={previousStory}
+          stories={item.stories}
+          progressIndex={0}
+          maxVideoDuration={15}
+          renderHeaderComponent={() => (
+            <UserHeaderView
+              userImage={{ uri: item.profile ?? '' }}
+              userName={item.username}
+              userMessage={item.title}
+              onClosePress={() => {
+                onComplete?.();
+              }}
+            />
+          )}
+          renderFooterComponent={() => <Footer />}
+          {...props}
+          index={index}
+          userStoryIndex={storyIndex}
+        />
+      </Animated.View>
     </Animated.View>
-  </Animated.View>
-);
+  );
+};
 
 const MultiStoryContainer = ({
   stories,
@@ -108,10 +113,11 @@ const MultiStoryContainer = ({
           onViewableItemsChanged={onViewRef.current}
           viewabilityConfig={viewabilityConfig.current}
           decelerationRate={Metrics.isIOS ? 0.99 : 0.92}
-          keyExtractor={item => item.id!.toString()}
+          keyExtractor={item => item.title + item.id!.toString()}
           contentContainerStyle={{
             width: Metrics.screenWidth * stories.length,
           }}
+          extraData={storyIndex}
           renderItem={({ item, index }) => (
             <MultiStoryListItem
               {...{
@@ -123,6 +129,7 @@ const MultiStoryContainer = ({
                 storyIndex,
                 onComplete,
               }}
+              {...props}
             />
           )}
         />

--- a/src/components/MultiStoryContainer/hooks/useMultiStoryContainer.ts
+++ b/src/components/MultiStoryContainer/hooks/useMultiStoryContainer.ts
@@ -9,7 +9,7 @@ import { Metrics } from '../../../theme';
 import type { ViewConfig } from '../types';
 
 const useMultiStoryContainer = ({ ...props }) => {
-  const [storyIndex, setStoryIndex] = useState(props.storyIndex ?? 0);
+  const [storyIndex, setStoryIndex] = useState(props.userStoryIndex ?? 0);
   const scrollX = useValue(0);
   const previousIndex = useRef(0);
   const viewabilityConfig = useRef({

--- a/src/components/MultiStoryContainer/types.ts
+++ b/src/components/MultiStoryContainer/types.ts
@@ -1,10 +1,11 @@
 import type { ViewToken } from 'react-native';
-import type { StoriesType } from '../StoryView/types';
+import type { StoriesType, StoryContainerProps } from '../StoryView/types';
 
-export interface MultiStoryContainerProps {
+export interface MultiStoryContainerProps
+  extends Omit<StoryContainerProps, 'stories'> {
   stories: StoriesType[];
   onComplete?: () => void;
-  storyIndex?: number;
+  userStoryIndex?: number;
   visible?: boolean;
   onChangePosition?: (
     storyIndex: number,
@@ -12,7 +13,8 @@ export interface MultiStoryContainerProps {
   ) => void | undefined;
 }
 
-export interface MultiStoryListItemProps {
+export interface MultiStoryListItemProps
+  extends Omit<StoryContainerProps, 'stories'> {
   item: StoriesType;
   index: number;
   storyIndex: number;

--- a/src/components/StoryView/ProgressBar.tsx
+++ b/src/components/StoryView/ProgressBar.tsx
@@ -1,43 +1,16 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Animated, LayoutRectangle, View } from 'react-native';
 import { useProgressBar } from './hooks';
 import styles from './styles';
 import type { ProgressBarProps } from './types';
 
 const ProgressBar = (props: ProgressBarProps) => {
-  const { index, currentIndex } = props;
-
-  const {
-    barActiveColor,
-    barInActiveColor,
-    barHeight,
-    scale,
-    setWidth,
-    setPauseTime,
-    startTime,
-    setStartTime,
-  } = useProgressBar(props);
+  const { barActiveColor, barInActiveColor, barHeight, scale, setWidth } =
+    useProgressBar(props);
 
   const onLayoutAdded = (evt: LayoutRectangle) => {
     setWidth(evt.width);
   };
-
-  useEffect(() => {
-    setPauseTime(0);
-    setStartTime(0);
-  }, [currentIndex, setStartTime, setPauseTime, props?.storyIndex]);
-
-  useEffect(() => {
-    if (index === currentIndex) {
-      if (props.pause) {
-        const endTime = Date.now();
-        setPauseTime(endTime ?? 5);
-      }
-      if (startTime === 0) {
-        setStartTime(Date.now());
-      }
-    }
-  }, [currentIndex, index, props.pause, setPauseTime, setStartTime, startTime]);
 
   return (
     <View

--- a/src/components/StoryView/ProgressView.tsx
+++ b/src/components/StoryView/ProgressView.tsx
@@ -27,6 +27,7 @@ const ProgressView = (props: ProgressBarsProps) => {
           index={index}
           key={i}
           storyIndex={props?.storyIndex}
+          currentUserIndex={props?.index}
           barStyle={props.barStyle}
           duration={props.duration || 3}
           currentIndex={props.currentIndex}

--- a/src/components/StoryView/StoryContainer.tsx
+++ b/src/components/StoryView/StoryContainer.tsx
@@ -13,9 +13,10 @@ import styles from './styles';
 import { ClickPosition, StoryContainerProps } from './types';
 
 const StoryContainer = ({
-  headerComponent,
-  customView,
-  footerComponent,
+  renderHeaderComponent,
+  renderFooterComponent,
+  renderCustomView,
+  userStories,
   enableProgress = true,
   headerViewProps,
   customViewProps,
@@ -91,7 +92,7 @@ const StoryContainer = ({
                 next={() => onArrowClick(ClickPosition.Right)}
                 isLoaded={isLoaded}
                 duration={duration}
-                storyIndex={props?.storyIndex ?? 0}
+                storyIndex={props?.userStoryIndex ?? 0}
                 index={props?.index ?? 0}
                 pause={enableProgress && isPause}
                 stories={props.stories}
@@ -103,20 +104,38 @@ const StoryContainer = ({
               />
             </View>
           )}
-          {headerComponent && (
+          {renderHeaderComponent && (
             <View style={[styles.topView, { opacity }]} {...headerViewProps}>
-              {headerComponent}
+              <>
+                {renderHeaderComponent?.(
+                  userStories,
+                  progressIndex,
+                  props?.userStoryIndex
+                )}
+              </>
             </View>
           )}
-          {customView && (
+          {renderCustomView && (
             <View style={[styles.customView, { opacity }]} {...customViewProps}>
-              {customView}
+              <>
+                {renderCustomView?.(
+                  userStories,
+                  progressIndex,
+                  props?.userStoryIndex
+                )}
+              </>
             </View>
           )}
         </View>
-        {footerComponent && (
+        {renderFooterComponent && (
           <View style={[styles.bottomView, { opacity }]} {...footerViewProps}>
-            {footerComponent}
+            <>
+              {renderFooterComponent?.(
+                userStories,
+                progressIndex,
+                props?.userStoryIndex
+              )}
+            </>
           </View>
         )}
       </>

--- a/src/components/StoryView/hooks/useProgressBar.ts
+++ b/src/components/StoryView/hooks/useProgressBar.ts
@@ -15,15 +15,21 @@ const useProgressBar = ({
   const scaleRef = useRef(new Animated.Value(0));
   const scale = scaleRef?.current;
   const [width, setWidth] = useState<number>(0);
-  const [pauseTime, setPauseTime] = useState<number>(0);
-  const [startTime, setStartTime] = useState<number>(0);
+  const [remainingTime, setRemainingTime] = useState<number>(duration);
 
   // Restart ProgressBar when story changes
   useEffect(() => {
     if (index === currentIndex) {
       scale.setValue(0);
+      setRemainingTime(duration);
     }
-  }, [storyIndex, currentIndex, index, scale]);
+  }, [storyIndex, currentIndex, index, scale, duration, setRemainingTime]);
+
+  useEffect(() => {
+    const progressBarWidth =
+      Number.parseInt(JSON.stringify(scaleRef.current), 10) ?? 0;
+    setRemainingTime(duration - (progressBarWidth * duration) / width);
+  }, [props?.pause, width, duration]);
 
   const barActiveColor = props?.barStyle?.barActiveColor ?? Colors.activeColor;
   const barInActiveColor =
@@ -31,17 +37,15 @@ const useProgressBar = ({
   const barHeight = props?.barStyle?.barHeight ?? 2;
 
   const getDuration = useCallback(() => {
-    const totalPlaytime = duration * 1000;
     if (props.pause) {
       scale.stopAnimation();
       return 0;
     }
-    if (pauseTime === 0) {
-      return totalPlaytime;
+    if (remainingTime === 0) {
+      return duration * 1000;
     }
-    const lastTime = pauseTime - startTime;
-    return totalPlaytime - lastTime;
-  }, [duration, pauseTime, props.pause, scale, startTime]);
+    return remainingTime * 1000;
+  }, [remainingTime, scale, props?.pause, duration]);
 
   useEffect(() => {
     switch (active) {
@@ -69,7 +73,7 @@ const useProgressBar = ({
       default:
         return scale.setValue(0);
     }
-  }, [storyIndex, active, getDuration, props, scale, width]);
+  }, [active, getDuration, props, scale, width]);
 
   return {
     barActiveColor,
@@ -78,9 +82,6 @@ const useProgressBar = ({
     scale,
     width,
     setWidth,
-    startTime,
-    setPauseTime,
-    setStartTime,
   };
 };
 

--- a/src/components/StoryView/hooks/useStoryContainer.ts
+++ b/src/components/StoryView/hooks/useStoryContainer.ts
@@ -16,24 +16,26 @@ const useStoryContainer = (props: StoryContainerProps) => {
   const [progressIndex, setProgressIndex] = useState(props?.progressIndex ?? 0);
   const [isLoaded, setLoaded] = useState(false);
   const [duration, setDuration] = useState(0);
-  const [isPause, setPause] = useState(false);
+  const [isPause, setPause] = useState(true);
   const [visibleElements, setVisibleElements] = useState(true);
   const appState = useRef(AppState.currentState);
 
   const isKeyboardVisible = useKeyboardListener();
 
   useEffect(() => {
-    setPause(isKeyboardVisible);
-  }, [isKeyboardVisible]);
+    if (props?.index === props?.userStoryIndex) {
+      setPause(isKeyboardVisible);
+    }
+  }, [isKeyboardVisible, props?.index, props?.userStoryIndex]);
 
   const onImageLoaded = () => {
     setLoaded(true);
   };
 
   useEffect(() => {
-    const isStoryNotFocused = props?.index !== props?.storyIndex;
+    const isStoryNotFocused = props?.index !== props?.userStoryIndex;
     setPause(isStoryNotFocused);
-  }, [props?.storyIndex, props?.index]);
+  }, [props?.userStoryIndex, props?.index]);
 
   const handleAppStateChange = (nextAppState: AppStateStatus) => {
     const isBackgroundState =
@@ -91,7 +93,7 @@ const useStoryContainer = (props: StoryContainerProps) => {
     } else if (position < 0) {
       props?.previousStory?.();
     } else if (position < props.stories.length) {
-      props?.onChangePosition?.(position, props?.storyIndex);
+      props?.onChangePosition?.(position, props?.userStoryIndex);
       setProgressIndex(position);
     } else {
       props?.onComplete?.();
@@ -104,8 +106,10 @@ const useStoryContainer = (props: StoryContainerProps) => {
   };
 
   const onStoryPressRelease = () => {
-    setVisibleElements(true);
-    setPause(false);
+    if (isPause && !visibleElements) {
+      setVisibleElements(true);
+      setPause(false);
+    }
   };
 
   const rootStyle = StyleSheet.flatten([styles.container, props?.style]);

--- a/src/components/StoryView/types.ts
+++ b/src/components/StoryView/types.ts
@@ -1,4 +1,4 @@
-import type { FunctionComponentElement, RefObject } from 'react';
+import type { RefObject } from 'react';
 import type {
   ActivityIndicatorProps,
   ImageProps,
@@ -10,7 +10,6 @@ import type {
   ViewStyle,
 } from 'react-native';
 import type { OnLoadData, VideoProperties } from 'react-native-video';
-import type { FooterComponentProps } from '../Footer/types';
 
 export enum StroyTypes {
   Image = 'image',
@@ -61,6 +60,7 @@ export interface ProgressBarProps extends ProgressBarCommonProps {
   index: number;
   length: number;
   storyIndex: number;
+  currentUserIndex?: number;
 }
 
 export interface ProgressBarsProps extends ProgressBarCommonProps {
@@ -101,16 +101,30 @@ export interface ProgressiveImageProps {
 
 export interface StoryContainerProps extends CommonProps {
   stories: StoryType[];
+  userStories?: StoriesType;
   visible?: boolean | undefined;
   index?: number | undefined;
+  userStoryIndex?: number | undefined;
   storyIndex?: number | undefined;
   isShowReply?: boolean | undefined;
-  headerComponent?: FunctionComponentElement<CommonProps> | undefined;
+  renderHeaderComponent?: (
+    userStories?: StoriesType,
+    progressIndex?: number,
+    userStoryIndex?: number
+  ) => {} | undefined;
+  renderFooterComponent?: (
+    userStories?: StoriesType,
+    progressIndex?: number,
+    userStoryIndex?: number
+  ) => {} | undefined;
   userProfile?: UserProps | undefined;
   footerView?: FooterViewProps | undefined;
-  footerComponent?: FooterComponentProps;
-  onComplete?: Function;
-  customView?: FunctionComponentElement<CommonProps> | undefined;
+  onComplete?: () => void;
+  renderCustomView?: (
+    userStories?: StoriesType,
+    progressIndex?: number,
+    userStoryIndex?: number
+  ) => {} | undefined;
   backgroundColor?: string;
   style?: ViewStyle;
   progressIndex?: number | undefined;
@@ -123,8 +137,8 @@ export interface StoryContainerProps extends CommonProps {
   sourceIndicatorProps?: ActivityIndicatorProps;
   videoProps?: VideoProperties;
   onChangePosition?: (
-    storyIndex: number,
-    userIndex?: number
+    progressIndex: number,
+    userStoryIndex?: number
   ) => void | undefined;
   previousStory?: () => void | undefined;
   nextStory?: () => void;


### PR DESCRIPTION
#### Description:
UNT-T9534 Add Props customisation in MultiStory

- add: `storyContainerProps`  in `MultiStory` to customise all props of StoryContainer
- refactor: Props in `StoryContainer`
  - refactor: `storyIndex` to `userStoryIndex`
  - replace: `headerComponent`, `footerComponent` & `customView` with `renderHeaderComponent`, `renderFooterComponent` and `renderCustomView` methods
- refactor: story `pause` logic 
  - Earlier logic was based on Date.Now() while pausing story calculate passed time was causing issues.
  - remove: `startTime` and `pauseTime` logic
  - refactor:  based on filled progressBar width calculating filled duration 


--------------------


#### Fix :

N/A


--------------------

#### Dev Testing :
iOS Simulator