### PR TITLE
feat(UNT-T10111): add seen story functioning in multi story and avatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ const userStories = [
           type: 'image', //image or video type of story
           duration: 5, //default duration
           storyId: 1,
+          isSeen: false,
         },
         {
           id: 1,
@@ -100,6 +101,7 @@ const userStories = [
           type: 'video',
           duration: 15,
           storyId: 1,
+          isSeen: false,
         },
       ],
     },
@@ -343,7 +345,8 @@ Pass any custom view in story view. It will be rendered on top of story view as 
       type: 'image' | 'video';
       duration: number
       isReadMore: boolean
-      storyId: number
+      storyId: number,
+      isSeen?: boolean,
     }
   ]
 }]
@@ -355,15 +358,15 @@ Pass any custom view in story view. It will be rendered on top of story view as 
 
 <br />
 
-> | Name                | Default | Type                                            | <div style="width:290px">Description</div>                                  |
-> | :------------------ | :-----: | :---------------------------------------------- | --------------------------------------------------------------------------- |
-> | **stories\***       |    0    | StoriesType[]                                   | Array of multiple user stories                                              |
-> | ref                 |  null   | MultiStoryRef                                   | To access `close` story method                                              |
-> | storyContainerProps |   {}    | StoryContainerProps                             | Customize all story props, detailed props in below `StoryContainer` section |
-> | avatarProps         |   {}    | [StoryAvatarStyleProps](#StoryAvatarStyleProps) | Customize avatar component styles                                           |
-> | onChangePosition    |  null   | (progressIndex, storyIndex) => {}               | Callback when progress index changes                                        |
-> | onComplete          |  null   | () => {}                                        | Callback when stories closed or complete                                    |
-> | `props`             |    -    | FlatListProps                                   | Pass any `FlatList` props to customize horizontal user list                 |
+> | Name                | Default | Type                                            | <div style="width:290px">Description</div>                                                                              |
+> | :------------------ | :-----: | :---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+> | **stories\***       |    0    | StoriesType[]                                   | Array of multiple user stories                                                                                          |
+> | ref                 |  null   | MultiStoryRef                                   | To access `close` story method                                                                                          |
+> | storyContainerProps |   {}    | StoryContainerProps                             | Customize all story props, detailed props in below `StoryContainer` section                                             |
+> | avatarProps         |   {}    | [StoryAvatarStyleProps](#StoryAvatarStyleProps) | Customize avatar component styles                                                                                       |
+> | onChangePosition    |  null   | (progressIndex, storyIndex) => {}               | Callback when progress index changes                                                                                    |
+> | onComplete          |  null   | (viewedStories?: Array<boolean[]>) => void      | Callback when stories closed or completes. `viewedStories` contains multi array of boolean whether story is seen or not |
+> | `props`             |    -    | FlatListProps                                   | Pass any `FlatList` props to customize horizontal user list                                                             |
 
 ---
 
@@ -371,14 +374,15 @@ Pass any custom view in story view. It will be rendered on top of story view as 
 
 <br />
 
-> | Name           | Default | Type           | <div style="width:290px">Description</div> |
-> | :------------- | :-----: | :------------- | ------------------------------------------ |
-> | userNameStyle  |    -    | TextStyle      | To change style of user name               |
-> | userImageStyle |    -    | ImageStyle     | To change style of user avatar             |
-> | containerStyle |    -    | ViewStyle      | To change style of image container         |
-> | userImageProps |    -    | ImageProps     | To customize image props                   |
-> | userNameProps  |    -    | ViewStyle      | To customize text props                    |
-> | rootProps      |    -    | PressableProps | To customize root view props               |
+> | Name                      | Default | Type           | <div style="width:290px">Description</div>                |
+> | :------------------------ | :-----: | :------------- | --------------------------------------------------------- |
+> | userNameStyle             |    -    | TextStyle      | To change style of user name                              |
+> | userImageStyle            |    -    | ImageStyle     | To change style of user avatar                            |
+> | containerStyle            |    -    | ViewStyle      | To change style of image container                        |
+> | userImageProps            |    -    | ImageProps     | To customize image props                                  |
+> | userNameProps             |    -    | ViewStyle      | To customize text props                                   |
+> | rootProps                 |    -    | PressableProps | To customize root view props                              |
+> | viewedStoryContainerStyle |    -    | ViewStyle      | To customize story avatar when all stories of it are seen |
 
 ---
 
@@ -406,24 +410,25 @@ Pass any custom view in story view. It will be rendered on top of story view as 
 
 <br />
 
-> | Name                    | Default | Type                                                       | <div style="width:290px">Description</div>                             |
-> | :---------------------- | :-----: | :--------------------------------------------------------- | ---------------------------------------------------------------------- |
-> | **visible\***           |  false  | boolean                                                    | Hide / show story view                                                 |
-> | **stories\***           |   []    | StoryType[]                                                | Array of stories                                                       |
-> | backgroundColor         | #000000 | string                                                     | Background color of story view                                         |
-> | maxVideoDuration        |  null   | number                                                     | Override video progress duration (default is actual duration of video) |
-> | style                   |   {}    | ViewStyle                                                  | Style of story view                                                    |
-> | showSourceIndicator     |  true   | boolean                                                    | Display indicator while video loading                                  |
-> | sourceIndicatorProps    |   {}    | ActivityIndicatorProps                                     | To override indicator props                                            |
-> | onComplete              |  null   | () => {}                                                   | Callback when all stories completes                                    |
-> | renderHeaderComponent   |  null   | (callback: [CallbackProps](#CallbackProps)) => JSX.Element | Render Header component (`ProfileHeader`) or custom component          |
-> | renderFooterComponent   |  null   | (callback: [CallbackProps](#CallbackProps)) => JSX.Element | Render Footer component (`Footer`) or custom component                 |
-> | renderCustomView        |  null   | (callback: [CallbackProps](#CallbackProps)) => JSX.Element | Render any custom view on Story                                        |
-> | storyContainerViewProps |   {}    | ViewProps                                                  | Root story view props                                                  |
-> | headerViewProps         |   {}    | ViewProps                                                  | Header view wrapper props                                              |
-> | footerViewProps         |   {}    | ViewProps                                                  | Footer view wrapper props                                              |
-> | customViewProps         |   {}    | ViewProps                                                  | Custom view wrapper props                                              |
-> | videoProps              |   {}    | VideoProperties                                            | To override video properties                                           |
+> | Name                    | Default | Type                                                       | <div style="width:290px">Description</div>                                       |
+> | :---------------------- | :-----: | :--------------------------------------------------------- | -------------------------------------------------------------------------------- |
+> | **visible\***           |  false  | boolean                                                    | Hide / show story view                                                           |
+> | **stories\***           |   []    | StoryType[]                                                | Array of stories                                                                 |
+> | backgroundColor         | #000000 | string                                                     | Background color of story view                                                   |
+> | maxVideoDuration        |  null   | number                                                     | Override video progress duration (default is actual duration of video)           |
+> | style                   |   {}    | ViewStyle                                                  | Style of story view                                                              |
+> | showSourceIndicator     |  true   | boolean                                                    | Display indicator while video loading                                            |
+> | sourceIndicatorProps    |   {}    | ActivityIndicatorProps                                     | To override indicator props                                                      |
+> | onComplete              |  null   | () => {}                                                   | Callback when all stories completes                                              |
+> | renderHeaderComponent   |  null   | (callback: [CallbackProps](#CallbackProps)) => JSX.Element | Render Header component (`ProfileHeader`) or custom component                    |
+> | renderFooterComponent   |  null   | (callback: [CallbackProps](#CallbackProps)) => JSX.Element | Render Footer component (`Footer`) or custom component                           |
+> | renderCustomView        |  null   | (callback: [CallbackProps](#CallbackProps)) => JSX.Element | Render any custom view on Story                                                  |
+> | storyContainerViewProps |   {}    | ViewProps                                                  | Root story view props                                                            |
+> | headerViewProps         |   {}    | ViewProps                                                  | Header view wrapper props                                                        |
+> | footerViewProps         |   {}    | ViewProps                                                  | Footer view wrapper props                                                        |
+> | customViewProps         |   {}    | ViewProps                                                  | Custom view wrapper props                                                        |
+> | videoProps              |   {}    | VideoProperties                                            | To override video properties                                                     |
+> | ref                     |   {}    | StoryRef                                                   | To access 'pause' story method and 'viewedStories' stories object (Single Story) |
 
 ---
 
@@ -522,11 +527,11 @@ $ yarn example android   // For Android
 # TODO
 
 - [ ] Customize StoryAvatar in reference of Instagram
-- [ ] Add `seen` functionality on StoryAvatar and stories
 - [ ] Customized Story example
 - [ ] Refactor Cube transition (make perfect cube in reference of Instagram)
 - [ ] Add Support for different transitions effect
 - [ ] Landscape support
+- [ ] Optimize video loading on android
 
 <br />
 

--- a/example/src/constants/stories.ts
+++ b/example/src/constants/stories.ts
@@ -13,6 +13,7 @@ const stories = [
         duration: 3,
         isReadMore: true,
         storyId: 1,
+        isSeen: false
       },
       {
         id: 2,
@@ -21,6 +22,7 @@ const stories = [
         duration: 4,
         isReadMore: true,
         storyId: 1,
+        isSeen: false
       },
       {
         id: 3,
@@ -29,8 +31,9 @@ const stories = [
         duration: 15,
         isReadMore: true,
         storyId: 1,
-      },
-    ],
+        isSeen: false
+      }
+    ]
   },
   {
     id: 2,
@@ -46,6 +49,7 @@ const stories = [
         duration: 5,
         isReadMore: true,
         storyId: 2,
+        isSeen: false
       },
       {
         id: 1,
@@ -54,8 +58,9 @@ const stories = [
         duration: 10,
         isReadMore: true,
         storyId: 2,
-      },
-    ],
+        isSeen: false
+      }
+    ]
   },
   {
     id: 3,
@@ -71,6 +76,7 @@ const stories = [
         duration: 5,
         isReadMore: true,
         storyId: 3,
+        isSeen: false
       },
       {
         id: 1,
@@ -79,8 +85,9 @@ const stories = [
         duration: 10,
         isReadMore: true,
         storyId: 3,
-      },
-    ],
+        isSeen: false
+      }
+    ]
   },
   {
     id: 4,
@@ -96,6 +103,7 @@ const stories = [
         duration: 5,
         isReadMore: true,
         storyId: 4,
+        isSeen: false
       },
       {
         id: 1,
@@ -104,8 +112,9 @@ const stories = [
         duration: 10,
         isReadMore: true,
         storyId: 4,
-      },
-    ],
+        isSeen: false
+      }
+    ]
   },
   {
     id: 5,
@@ -121,9 +130,10 @@ const stories = [
         duration: 5,
         isReadMore: true,
         storyId: 4,
-      },
-    ],
-  },
+        isSeen: false
+      }
+    ]
+  }
 ];
 
 export default stories;

--- a/example/src/modules/MultiStory/MultiStoryScreen.tsx
+++ b/example/src/modules/MultiStory/MultiStoryScreen.tsx
@@ -1,15 +1,31 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { ImageBackground, View, Text } from 'react-native';
 import { MultiStory } from '../../../../src';
 import type { MultiStoryRef } from 'react-native-story-view';
 import { stories, Strings } from '../../constants';
-import { Colors } from '../../theme';
-import styles from './styles';
 import { Header, Footer } from '../../components';
+import { Colors } from '../../theme';
 import Images from '../../assets';
+import styles from './styles';
 
 const MultiStoryScreen = () => {
   const multiStoryRef = useRef<MultiStoryRef>(null);
+  const [userStories, setUserStories] = useState(
+    JSON.parse(JSON.stringify(stories))
+  );
+
+  const onStoryClose = (viewedStories?: Array<boolean[]>) => {
+    if (viewedStories == null || viewedStories == undefined) return;
+    const stories = [...userStories];
+    userStories.map((_: any, index: number) => {
+      userStories[index].stories.map((_: any, subIndex: number) => {
+        stories[index].stories[subIndex].isSeen =
+          viewedStories[index][subIndex];
+      });
+    });
+    setUserStories([...stories]);
+  };
+
   return (
     <ImageBackground
       style={styles.container}
@@ -18,9 +34,18 @@ const MultiStoryScreen = () => {
       <View style={styles.storyWrapper}>
         <Text style={styles.albumText}>{Strings.album}</Text>
         <MultiStory
-          stories={stories}
+          stories={userStories}
           ItemSeparatorComponent={() => <View style={styles.separator} />}
           ref={multiStoryRef}
+          /* callback after multi story is closed
+            `viewedStories` contains multi dimension array of booleans whether story is seen or not
+          */
+          onComplete={onStoryClose}
+          avatarProps={{
+            viewedStoryContainerStyle: {
+              borderColor: Colors.lightGrey
+            }
+          }}
           storyContainerProps={{
             renderHeaderComponent: ({ userStories }) => (
               <Header {...{ userStories, multiStoryRef }} />

--- a/example/src/modules/Story/StoryScreen.tsx
+++ b/example/src/modules/Story/StoryScreen.tsx
@@ -1,24 +1,59 @@
 import React, { useState } from 'react';
 import { Modal, SafeAreaView, View } from 'react-native';
 import { Footer, Header } from '../../components';
-import { StoryAvatar, StoryContainer } from '../../../../src';
+import {
+  StoryAvatar,
+  StoryContainer,
+  StoryRef,
+  StoryType
+} from '../../../../src';
 import { stories } from '../../constants';
 import styles from './styles';
+import { useRef } from 'react';
 
 const StoryScreen = () => {
   const [isStoryViewVisible, setIsStoryViewShow] = useState<boolean>(false);
+  const ref = useRef<StoryRef>(null);
   const index = 0;
+  const [userStories, setUserStories] = useState(
+    JSON.parse(JSON.stringify(stories[index]))
+  );
+
+  const viewedStories = useRef(
+    Array(userStories.stories.length)
+      .fill(userStories.stories)
+      .map((item, index) => item[index].isSeen ?? false)
+  );
+
   const openStories = () => {
     setIsStoryViewShow(true);
   };
+
   const closeStory = () => {
+    viewedStories.current = ref?.current?.viewedStories ?? [];
+    const clonedUserStories = { ...userStories };
+    clonedUserStories.stories.map((item: StoryType, index: number) => {
+      item.isSeen = viewedStories.current?.[index] ?? false;
+    });
+    setUserStories({ ...clonedUserStories });
     setIsStoryViewShow(false);
   };
+
+  const storyInitialIndex: number = viewedStories?.current?.findIndex(
+    (val: boolean) => !val
+  );
 
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.storyAvatarContainer}>
-        <StoryAvatar {...{ openStories, index, item: stories[index] }} />
+        <StoryAvatar
+          {...{
+            openStories,
+            index,
+            item: userStories,
+            viewedStories: [viewedStories.current]
+          }}
+        />
       </View>
       <Modal
         visible={isStoryViewVisible}
@@ -27,16 +62,15 @@ const StoryScreen = () => {
         <SafeAreaView style={styles.storyContainer}>
           <StoryContainer
             visible
-            stories={stories[index].stories}
+            ref={ref}
+            progressIndex={storyInitialIndex < 0 ? 0 : storyInitialIndex}
+            stories={userStories.stories}
             maxVideoDuration={10}
             renderHeaderComponent={({ progressIndex }) => (
-              <Header userStories={stories[index]} onClosePress={closeStory} />
+              <Header userStories={userStories} onClosePress={closeStory} />
             )}
             renderFooterComponent={({ progressIndex, story }) => (
-              <Footer
-                userStories={stories[index]}
-                {...{ story, progressIndex }}
-              />
+              <Footer userStories={userStories} {...{ story, progressIndex }} />
             )}
             //Callback when status view completes
             onComplete={closeStory}

--- a/example/src/theme/Colors.ts
+++ b/example/src/theme/Colors.ts
@@ -2,8 +2,9 @@ const colors = {
   red: '#FF0000',
   blue: '#0000FF',
   white: '#FFFFFF',
-  black: "#000000",
-  grey: '#101010'
+  black: '#000000',
+  grey: '#101010',
+  lightGrey: '#FFFFFF7F'
 };
 
 export default colors;

--- a/src/components/MultiStory/types.ts
+++ b/src/components/MultiStory/types.ts
@@ -4,9 +4,10 @@ import type { StoriesType, StoryContainerProps } from '../StoryView/types';
 
 export interface MultiStoryProps extends Partial<FlatListProps<any>> {
   stories: StoriesType[];
-  onComplete?: () => void;
+  onComplete?: (viewedStories?: Array<boolean[]>) => void;
   onChangePosition?: (progressIndex: number, storyIndex: number) => void;
   avatarProps?: StoryAvatarStyleProps;
+  viewedStories?: Array<boolean[]>;
   storyContainerProps?: Omit<StoryContainerProps, 'stories'>;
 }
 

--- a/src/components/MultiStoryContainer/MultiStoryContainer.tsx
+++ b/src/components/MultiStoryContainer/MultiStoryContainer.tsx
@@ -29,11 +29,15 @@ const MultiStoryListItem = forwardRef<ListItemRef, MultiStoryListItemProps>(
       previousStory,
       storyIndex,
       onComplete,
+      viewedStories,
       ...props
     }: MultiStoryListItemProps,
     ref
   ) => {
     const storyRef = useRef<StoryRef>(null);
+    const storyInitialIndex: number = viewedStories?.[index]?.findIndex(
+      (val: boolean) => !val
+    );
 
     useImperativeHandle(ref, () => ({
       onScrollBegin: () => storyRef?.current?.pause(true),
@@ -50,7 +54,7 @@ const MultiStoryListItem = forwardRef<ListItemRef, MultiStoryListItemProps>(
             nextStory={nextStory}
             previousStory={previousStory}
             stories={item.stories}
-            progressIndex={0}
+            progressIndex={storyInitialIndex < 0 ? 0 : storyInitialIndex}
             maxVideoDuration={15}
             renderHeaderComponent={() => (
               <ProfileHeader
@@ -77,6 +81,7 @@ const MultiStoryContainer = ({
   stories,
   visible,
   onComplete,
+  viewedStories = [],
   ...props
 }: MultiStoryContainerProps) => {
   const flatListRef = useRef<any>(null);
@@ -161,6 +166,7 @@ const MultiStoryContainer = ({
                 previousStory,
                 storyIndex,
                 onComplete,
+                viewedStories,
               }}
               {...props}
             />

--- a/src/components/MultiStoryContainer/types.ts
+++ b/src/components/MultiStoryContainer/types.ts
@@ -7,6 +7,7 @@ export interface MultiStoryContainerProps
   onComplete?: () => void;
   userStoryIndex?: number;
   visible?: boolean;
+  viewedStories: Array<boolean[]>;
   onChangePosition?: (
     storyIndex: number,
     userIndex?: number
@@ -19,6 +20,7 @@ export interface MultiStoryListItemProps
   index: number;
   storyIndex: number;
   animatedTransitionStyle: any;
+  viewedStories: Array<boolean[]>;
   nextStory?: () => void;
   previousStory?: () => void;
   onComplete?: () => void;

--- a/src/components/StoryAvatar/StoryAvatar.tsx
+++ b/src/components/StoryAvatar/StoryAvatar.tsx
@@ -7,19 +7,27 @@ const StoryAvatar = ({
   item,
   index,
   openStories,
+  viewedStories = [],
   userNameStyle,
   userImageStyle,
   userImageProps,
+  viewedStoryContainerStyle,
   userNameProps,
   rootProps,
   containerStyle,
 }: StoryAvatarProps) => {
+  const isUserStorySeen: boolean = viewedStories?.[index]?.every(
+    (val: boolean) => val
+  );
   const _userNameStyle = StyleSheet.flatten([styles.username, userNameStyle]);
   const _userImageStyle = StyleSheet.flatten([styles.image, userImageStyle]);
   const _containerStyle = StyleSheet.flatten([
     styles.imageContainer,
     containerStyle,
+    (isUserStorySeen && viewedStoryContainerStyle) ??
+      styles.viewedStoryContainer,
   ]);
+
   return (
     <Pressable onPress={() => openStories?.(index!)} {...rootProps}>
       <View style={_containerStyle}>

--- a/src/components/StoryAvatar/__tests__/__snapshots__/StoryAvatar.test.tsx.snap
+++ b/src/components/StoryAvatar/__tests__/__snapshots__/StoryAvatar.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`StoryAvatar Component Match Snapshot 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "borderColor": "#CA1D7E",
+        "borderColor": "#FFFFFF7F",
         "borderRadius": 52.5,
         "borderWidth": 2,
         "height": 105,

--- a/src/components/StoryAvatar/styles.ts
+++ b/src/components/StoryAvatar/styles.ts
@@ -18,6 +18,9 @@ const styles = StyleSheet.create({
     borderWidth: 2,
     marginRight: moderateScale(16),
   },
+  viewedStoryContainer: {
+    borderColor: Colors.inActiveColor,
+  },
   username: {
     alignSelf: 'center',
     marginRight: moderateScale(16),

--- a/src/components/StoryAvatar/types.ts
+++ b/src/components/StoryAvatar/types.ts
@@ -10,7 +10,8 @@ import type { StoriesType } from '../StoryView/types';
 
 export interface StoryAvatarProps extends StoryAvatarStyleProps {
   item?: StoriesType;
-  index?: number;
+  index: number;
+  viewedStories?: Array<boolean[]>;
   openStories?: (position: number) => void;
 }
 
@@ -21,4 +22,5 @@ export interface StoryAvatarStyleProps {
   userImageProps?: ImageProps;
   userNameProps?: TextProps;
   rootProps?: PressableProps;
+  viewedStoryContainerStyle?: ViewStyle;
 }

--- a/src/components/StoryView/ProfileHeader.tsx
+++ b/src/components/StoryView/ProfileHeader.tsx
@@ -39,6 +39,13 @@ export default memo(function ProfileHeader({
     closeIconStyle,
   ]);
 
+  const touchPos = {
+    top: 20,
+    bottom: 30,
+    left: 30,
+    right: 30,
+  };
+
   return (
     <View style={_rootStyle} {...rest}>
       {!!userImage && (
@@ -63,7 +70,7 @@ export default memo(function ProfileHeader({
         )}
       </View>
       {customCloseButton ?? (
-        <TouchableOpacity onPress={() => onClosePress?.()}>
+        <TouchableOpacity onPress={() => onClosePress?.()} hitSlop={touchPos}>
           <Image
             source={Icons.closeIcon}
             style={_closeIconStyle}

--- a/src/components/StoryView/StoryContainer.tsx
+++ b/src/components/StoryView/StoryContainer.tsx
@@ -34,6 +34,12 @@ const StoryContainer = forwardRef<StoryRef, StoryContainerProps>(
     }: StoryContainerProps,
     ref
   ) => {
+    const viewedStories = useRef<boolean[]>(
+      Array(props?.stories?.length)
+        .fill(props?.stories)
+        .map((item, index) => item?.[index]?.isSeen ?? false)
+    );
+
     const {
       progressIndex,
       isPause,
@@ -52,7 +58,7 @@ const StoryContainer = forwardRef<StoryRef, StoryContainerProps>(
       onStoryPressRelease,
       rootStyle,
       containerStyle,
-    } = useStoryContainer(props);
+    } = useStoryContainer(props, viewedStories);
 
     const viewRef = useRef<View>(null);
 
@@ -62,6 +68,7 @@ const StoryContainer = forwardRef<StoryRef, StoryContainerProps>(
           setPause(pause);
         }
       },
+      viewedStories: viewedStories.current,
     }));
 
     useEffect(() => {

--- a/src/components/StoryView/hooks/useStoryContainer.ts
+++ b/src/components/StoryView/hooks/useStoryContainer.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  MutableRefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import {
   AppState,
   AppStateStatus,
@@ -10,18 +16,21 @@ import type { OnLoadData } from 'react-native-video';
 import { useKeyboardListener } from '../../../hooks';
 import { Colors, Metrics } from '../../../theme';
 import styles from '../styles';
-import { ClickPosition, StoryContainerProps } from '../types';
+import { ClickPosition, StoryContainerProps, StoryMode } from '../types';
 
-const useStoryContainer = ({
-  onChangePosition,
-  ...props
-}: StoryContainerProps) => {
+const useStoryContainer = (
+  { onChangePosition, ...props }: StoryContainerProps,
+  viewedStories: MutableRefObject<boolean[]>
+) => {
   const [progressIndex, setProgressIndex] = useState(props?.progressIndex ?? 0);
   const [isLoaded, setLoaded] = useState(false);
   const [duration, setDuration] = useState(0);
   const [isPause, setPause] = useState(true);
   const [visibleElements, setVisibleElements] = useState(true);
   const appState = useRef(AppState.currentState);
+  const storyMode: StoryMode = props?.userStoryIndex
+    ? StoryMode.MultiStory
+    : StoryMode.SingleStory;
 
   const isKeyboardVisible = useKeyboardListener();
 
@@ -35,8 +44,18 @@ const useStoryContainer = ({
   useEffect(() => {
     if (props?.index === props?.userStoryIndex) {
       onChangePosition?.(progressIndex, props?.userStoryIndex);
+      if (storyMode === StoryMode.SingleStory) {
+        viewedStories.current[progressIndex] = true;
+      }
     }
-  }, [props?.index, props?.userStoryIndex, progressIndex, onChangePosition]);
+  }, [
+    storyMode,
+    viewedStories,
+    props?.index,
+    props?.userStoryIndex,
+    progressIndex,
+    onChangePosition,
+  ]);
 
   const onImageLoaded = () => {
     setLoaded(true);

--- a/src/components/StoryView/types.ts
+++ b/src/components/StoryView/types.ts
@@ -30,6 +30,11 @@ export enum ProgressState {
   Paused = 3,
 }
 
+export enum StoryMode {
+  MultiStory = 'MultiStory',
+  SingleStory = 'SingleStory',
+}
+
 export interface CommonProps {
   images?: Array<string>;
   duration?: number | undefined;
@@ -121,7 +126,7 @@ export interface StoryContainerProps extends CommonProps {
   renderFooterComponent?: (callback: CallbackProps) => JSX.Element;
   userProfile?: UserProps | undefined;
   footerView?: FooterViewProps | undefined;
-  onComplete?: () => void;
+  onComplete?: (viewedStories?: Array<boolean[]>) => void;
   renderCustomView?: (callback: CallbackProps) => JSX.Element;
   backgroundColor?: string;
   style?: ViewStyle;
@@ -192,4 +197,5 @@ export type StoriesType = {
 
 export type StoryRef = {
   pause: (pause: boolean) => void;
+  viewedStories: boolean[];
 };


### PR DESCRIPTION
#### Description:
UNT-T10111 Add seen story functioning in multi story and avatar

- add: story seen functionality in Multi Story
  - `viewedStories` arg in `onComplete` callback to get seen stories when user story is closed or completed
  - `isSeen` property in story object added
- add: story seen functionality in Story Avatar
  - avatar colour border change to 'grey' after story is seen
  - `viewedStoryContainerStyle` to customise story avatar look when story is seen
- add: story seen functionality in Single Story
  - `viewedStories` object exposed via ref to get all seen stories
- refactor: example project of MultiStory and SingleStory to add this functionality 
- doc: update ReadME file
  - add: props in MultiStory and StoryContainer
  - refactor: update TODO list

--------------------
#### Fix :

N/A

--------------------


#### Dev Testing :
Android:
Oppo A53 (Android 12)


iOS Simulator- iPhone 13 (15.5)