### PR TITLE
fix(UNT-T10177): video story takes some time to load

### DIFF
--- a/src/components/StoryView/StoryView.tsx
+++ b/src/components/StoryView/StoryView.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import Video, { OnLoadData } from 'react-native-video';
-import { Colors } from '../../theme';
+import { Colors, Metrics } from '../../theme';
 import ProgressiveImage from './ProgressiveImage';
 import styles from './styles';
 import { StoryViewProps, StroyTypes } from './types';
@@ -10,6 +10,7 @@ const StoryView = (props: StoryViewProps) => {
   const [loading, setLoading] = useState(true);
   const image = props?.stories?.[props?.progressIndex];
   const videoRef = useRef<Video>(null);
+  const videoData = useRef<OnLoadData>();
 
   useEffect(() => {
     if (props?.index === props?.storyIndex) {
@@ -20,6 +21,17 @@ const StoryView = (props: StoryViewProps) => {
   const onLoadStart = () => {
     setLoading(true);
   };
+
+  const loadVideo = () => {
+    if (videoData.current === undefined) return;
+    setTimeout(() => {
+      if (props?.index === props?.storyIndex) {
+        props?.onVideoLoaded && props?.onVideoLoaded(videoData.current!);
+        setLoading(false);
+      }
+    }, 250);
+  };
+
   return (
     <View style={styles.divStory} ref={props?.viewRef}>
       {image?.type === StroyTypes.Image ? (
@@ -43,16 +55,17 @@ const StoryView = (props: StoryViewProps) => {
           <Video
             ref={videoRef}
             resizeMode="contain"
-            paused={props.pause}
+            paused={props.pause || loading}
             source={{ uri: image?.url }}
             onError={(_error: any) => {
               setLoading(false);
             }}
             onLoadStart={onLoadStart}
             onLoad={(item: OnLoadData) => {
-              setLoading(false);
-              props?.onVideoLoaded && props?.onVideoLoaded(item);
+              videoData.current = item;
+              !Metrics.isIOS && loadVideo();
             }}
+            onReadyForDisplay={loadVideo}
             style={styles.contentVideoView}
             {...props?.videoProps}
           />

--- a/src/components/StoryView/__tests__/__snapshots__/StoryView.test.tsx.snap
+++ b/src/components/StoryView/__tests__/__snapshots__/StoryView.test.tsx.snap
@@ -93,7 +93,8 @@ exports[`StoryContainer component Match Snapshot 1`] = `
             onError={[Function]}
             onLoad={[Function]}
             onLoadStart={[Function]}
-            paused={false}
+            onReadyForDisplay={[Function]}
+            paused={true}
             resizeMode="contain"
             source={
               Object {
@@ -161,6 +162,8 @@ exports[`StoryView component Match Snapshot 1`] = `
     onError={[Function]}
     onLoad={[Function]}
     onLoadStart={[Function]}
+    onReadyForDisplay={[Function]}
+    paused={true}
     resizeMode="contain"
     source={
       Object {


### PR DESCRIPTION
#### Description:
UNT-T10177 Video story takes some time to load

Minor improvisation on video loading time

- add `onReadyForDisplay` prop, will be triggered when video ready to display first frame (iOS only - not working on android)
-  pause story until video is loaded and add minor timeout to start progress

--------------------
#### Fix :

N/A


--------------------

#### Dev Testing :
Android:
OnePlus Nord (Android 12)
Samsung Galaxy Tab A7 (Android 11)
Oppo A53 (Android 12)


iOS Simulator- iPhone 13 (15.5)