### PR TITLE
fix(UNT-T10260): handle progress bar on video buffering or no internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ It works on both android and iOS platforms.
 
 ## Installation
 
-##### 1. Install library, react-native-video and react-native-reanimated,
+##### 1. Install library, react-native-video, react-native-video-cache-control and react-native-reanimated
 
 ```bash
-$ npm install react-native-video react-native-reanimated react-native-story-view
+$ npm install react-native-video react-native-reanimated react-native-video-cache-control react-native-story-view
 # --- or ---
-$ yarn add react-native-video react-native-reanimated react-native-story-view
+$ yarn add react-native-video react-native-reanimated react-native-video-cache-control react-native-story-view
 ```
 
 ##### 2. Install cocoapods in the ios project
@@ -41,7 +41,7 @@ module.exports = {
   };
 ```
 
-##### Know more about [react-native-video](https://www.npmjs.com/package/react-native-video) and [react-native-reanimated](https://www.npmjs.com/package/react-native-reanimated)
+##### Know more about [react-native-video](https://www.npmjs.com/package/react-native-video), [react-native-reanimated](https://www.npmjs.com/package/react-native-reanimated) and [react-native-video-cache-control](https://www.npmjs.com/package/react-native-video-cache-control)
 
 ---
 

--- a/example/package.json
+++ b/example/package.json
@@ -18,7 +18,8 @@
     "react-native-reanimated": "^2.10.0",
     "react-native-safe-area-context": "^4.3.1",
     "react-native-screens": "^3.15.0",
-    "react-native-video": "^5"
+    "react-native-video": "^5",
+    "react-native-video-cache-control": "^1.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/example/react-native-config.js
+++ b/example/react-native-config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  project: {
+    ios: {},
+    android: {}
+  },
+
+  dependencies: {
+    'react-native-video': {
+      platforms: {
+        android: {
+          sourceDir: '../node_modules/react-native-video/android-exoplayer'
+        }
+      }
+    }
+  }
+};

--- a/example/src/modules/MultiStory/MultiStoryScreen.tsx
+++ b/example/src/modules/MultiStory/MultiStoryScreen.tsx
@@ -35,7 +35,7 @@ const MultiStoryScreen = () => {
         <Text style={styles.albumText}>{Strings.album}</Text>
         <MultiStory
           stories={userStories}
-          transitionMode={TransitionMode.Scale}
+          transitionMode={TransitionMode.Cube}
           ItemSeparatorComponent={() => <View style={styles.separator} />}
           ref={multiStoryRef}
           /* callback after multi story is closed

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,6 +1,12 @@
 const mock = jest.requireMock('react-native-reanimated');
 
 jest.mock('react-native-video', () => 'Video');
+
+jest.mock('react-native-video-cache-control', () => ({
+  __esModule: true,
+  default: () => {},
+}));
+
 jest.mock('react-native-reanimated', () => {
   return {
     ...mock,

--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
     "react": "*",
     "react-native": "*",
     "react-native-reanimated": ">=2.10.0",
-    "react-native-video": "*"
+    "react-native-video": "*",
+    "react-native-video-cache-control": ">=1.1.1"
   },
   "devDependencies": {
+    "react-native-video-cache-control": "^1.1.1",
     "@babel/core": "^7.12.9",
     "@babel/runtime": "^7.12.5",
     "@commitlint/cli": "^16.1.0",

--- a/src/components/MultiStoryContainer/MultiStoryContainer.tsx
+++ b/src/components/MultiStoryContainer/MultiStoryContainer.tsx
@@ -49,6 +49,7 @@ const MultiStoryListItem = forwardRef<ListItemRef, MultiStoryListItemProps>(
         <Animated.View style={animatedTransitionStyle(index)}>
           <StoryContainer
             visible={true}
+            key={index + item?.id}
             ref={storyRef}
             userStories={item}
             nextStory={nextStory}

--- a/src/components/StoryView/ProgressView.tsx
+++ b/src/components/StoryView/ProgressView.tsx
@@ -26,9 +26,12 @@ const ProgressView = (props: ProgressBarsProps) => {
         <ProgressBar
           index={index}
           key={i}
+          storyType={props?.stories[index].type}
           storyIndex={props?.storyIndex}
           currentUserIndex={props?.index}
           barStyle={props.barStyle}
+          videoDuration={props?.videoDuration}
+          setVideoDuration={props?.setVideoDuration}
           duration={props.duration || 3}
           currentIndex={props.currentIndex}
           next={props?.next}

--- a/src/components/StoryView/StoryContainer.tsx
+++ b/src/components/StoryView/StoryContainer.tsx
@@ -52,9 +52,13 @@ const StoryContainer = forwardRef<StoryRef, StoryContainerProps>(
       changeStory,
       setLoaded,
       setDuration,
+      videoDuration,
+      onVideoProgress,
+      onVideoEnd,
       onArrowClick,
       onStoryPressHold,
       isKeyboardVisible,
+      setVideoDuration,
       onStoryPressRelease,
       rootStyle,
       containerStyle,
@@ -101,6 +105,9 @@ const StoryContainer = forwardRef<StoryRef, StoryContainerProps>(
                 onVideoLoaded={onVideoLoaded}
                 onImageLoaded={onImageLoaded}
                 progressIndex={progressIndex}
+                videoDuration={videoDuration}
+                onVideoEnd={onVideoEnd}
+                onVideoProgress={onVideoProgress}
                 pause={isPause}
                 index={props?.index ?? 0}
                 storyIndex={props?.userStoryIndex ?? 0}
@@ -120,10 +127,12 @@ const StoryContainer = forwardRef<StoryRef, StoryContainerProps>(
                   isLoaded={isLoaded}
                   duration={duration}
                   storyIndex={props?.userStoryIndex ?? 0}
+                  currentIndex={progressIndex}
+                  setVideoDuration={setVideoDuration}
                   index={props?.index ?? 0}
+                  videoDuration={videoDuration ?? 0}
                   pause={enableProgress && isPause}
                   stories={props?.stories}
-                  currentIndex={progressIndex}
                   barStyle={props?.barStyle}
                   currentStory={props?.stories[progressIndex]}
                   length={props?.stories?.map((_, i) => i)}

--- a/src/components/StoryView/__tests__/__snapshots__/StoryView.test.tsx.snap
+++ b/src/components/StoryView/__tests__/__snapshots__/StoryView.test.tsx.snap
@@ -76,25 +76,23 @@ exports[`StoryContainer component Match Snapshot 1`] = `
             }
           }
         >
-          <ActivityIndicator
-            animating={true}
-            color="#575899"
-            size="small"
-            style={
+          <Video
+            bufferConfig={
               Object {
-                "flex": 1,
-                "left": "45%",
-                "position": "absolute",
-                "top": "50%",
+                "bufferForPlaybackAfterRebufferMs": 60000,
+                "bufferForPlaybackMs": 60000,
+                "minBufferMs": 60000,
               }
             }
-          />
-          <Video
+            onBuffer={[Function]}
+            onEnd={[Function]}
             onError={[Function]}
             onLoad={[Function]}
             onLoadStart={[Function]}
+            onProgress={[Function]}
             onReadyForDisplay={[Function]}
             paused={true}
+            posterResizeMode="contain"
             resizeMode="contain"
             source={
               Object {
@@ -107,6 +105,20 @@ exports[`StoryContainer component Match Snapshot 1`] = `
                 "borderRadius": 4,
                 "flex": 1,
                 "overflow": "hidden",
+              }
+            }
+          />
+          <ActivityIndicator
+            animating={true}
+            color="#575899"
+            pointerEvents="none"
+            size="small"
+            style={
+              Object {
+                "flex": 1,
+                "left": "45%",
+                "position": "absolute",
+                "top": "50%",
               }
             }
           />
@@ -159,11 +171,21 @@ exports[`StoryView component Match Snapshot 1`] = `
   }
 >
   <Video
+    bufferConfig={
+      Object {
+        "bufferForPlaybackAfterRebufferMs": 60000,
+        "bufferForPlaybackMs": 60000,
+        "minBufferMs": 60000,
+      }
+    }
+    onBuffer={[Function]}
     onError={[Function]}
     onLoad={[Function]}
     onLoadStart={[Function]}
+    onProgress={[Function]}
     onReadyForDisplay={[Function]}
     paused={true}
+    posterResizeMode="contain"
     resizeMode="contain"
     source={
       Object {

--- a/src/components/StoryView/types.ts
+++ b/src/components/StoryView/types.ts
@@ -10,7 +10,11 @@ import type {
   ViewProps,
   ViewStyle,
 } from 'react-native';
-import type { OnLoadData, VideoProperties } from 'react-native-video';
+import type {
+  OnLoadData,
+  OnProgressData,
+  VideoProperties,
+} from 'react-native-video';
 
 export enum StroyTypes {
   Image = 'image',
@@ -65,13 +69,18 @@ export interface ProgressBarProps extends ProgressBarCommonProps {
   active: number;
   index: number;
   length: number;
+  storyType?: string;
+  videoDuration: number[];
+  setVideoDuration: (duration: number[]) => void;
   storyIndex: number;
   currentUserIndex?: number;
 }
 
 export interface ProgressBarsProps extends ProgressBarCommonProps {
-  stories: Array<Object>;
+  stories: StoryType[];
   currentStory: Object;
+  videoDuration: number[];
+  setVideoDuration: (duration: number[]) => void;
   length: Array<number>;
   progress: Object;
   storyIndex: number;
@@ -81,6 +90,9 @@ export interface ProgressBarsProps extends ProgressBarCommonProps {
 export interface StoryViewProps {
   pause?: boolean;
   onVideoLoaded?: (arg0: OnLoadData) => void;
+  videoDuration: number[];
+  onVideoProgress?: (progressData?: OnProgressData) => void;
+  onVideoEnd?: () => void;
   onImageLoaded?: () => void;
   stories: StoryType[];
   showSourceIndicator?: boolean;


### PR DESCRIPTION
#### Description:
UNT-T10260 Handle progress bar on video buffering


- add: `react-native-video-cache-control` for caching (minor improvisation in iOS)
- refactor: progressbar logic for video 
  - add: `onVideoProgress` method to get current progress and based on that set ProgressBar
  - add: `onVideoEnd` to move story

--------------------
#### Fix :

- fix: handle progress bar on video buffering or no internet


--------------------

#### Pending

Proper video caching for android and iOS
Load improvisation of video


--------------------

#### Dev Testing :
Android:
OnePlus Nord (Android 12)
Oppo A53 (Android 12)


iOS Simulator- iPhone 13 (15.5)