### PR TITLE
docs(UNT-T10679): add android installation extra step

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # react-native-story-view
 
-[![npm version](https://img.shields.io/badge/npm%20package-0.0.1-orange)](https://www.npmjs.org/package/react-native-story-view) [![Android](https://img.shields.io/badge/Platform-Android-green?logo=android)](https://www.android.com) [![iOS](https://img.shields.io/badge/Platform-iOS-green?logo=apple)](https://developer.apple.com/ios) [![MIT](https://img.shields.io/badge/License-MIT-green)](https://opensource.org/licenses/MIT)
+[![npm version](https://img.shields.io/badge/npm%20package-0.0.2-orange)](https://www.npmjs.org/package/react-native-story-view) [![Android](https://img.shields.io/badge/Platform-Android-green?logo=android)](https://www.android.com) [![iOS](https://img.shields.io/badge/Platform-iOS-green?logo=apple)](https://developer.apple.com/ios) [![MIT](https://img.shields.io/badge/License-MIT-green)](https://opensource.org/licenses/MIT)
 
 ---
 
@@ -49,6 +49,23 @@ module.exports = {
           'react-native-reanimated/plugin',
       ],
   };
+```
+
+<br />
+
+#### Extra Step
+
+<b>Android:</b><br />
+If you're facing issue related to 'android-scalablevideoview' or 'videocache' module not found.
+Add this code in android's build.gradle
+
+```
+jcenter() {
+    content {
+        includeModule("com.yqritc", "android-scalablevideoview")
+        includeModule("com.danikula", "videocache")
+    }
+}
 ```
 
 ##### Know more about [react-native-video](https://www.npmjs.com/package/react-native-video), [react-native-reanimated](https://www.npmjs.com/package/react-native-reanimated), [react-native-gesture-handler ](https://www.npmjs.com/package/react-native-gesture-handler) and [react-native-video-cache-control](https://www.npmjs.com/package/react-native-video-cache-control)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-story-view",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "React Native component to provide status/stories feature.",
   "main": "lib/index",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
#### Description:

UNT-T10679 add android installation extra step

- refactor: ReadME file
  - add: extra installation steps in case of module not found in android
  - update: npm badge
- chore: bump minor package version to `0.0.2`